### PR TITLE
Add message schema

### DIFF
--- a/schema/cp1/metar.json
+++ b/schema/cp1/metar.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/iblsoft/swimdemo/schema/metar.json",
+    "title": "MET-SWIM AMQP CP1 Message - METAR/SPECI",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "address": {
+            "type": "string",
+            "enum": ["weather.aviation.metar"]
+        },
+        "priority": { "type": "integer", "minimum": 4, "maximum": 6 },
+        "subject": { "type": "string", "const": "weather.aviation.metar" },
+        "content-type": { "type": "string", "const": "application/xml" },
+        "content-encoding": { "type": "string", "enum": ["gzip", "identity"] },
+        "absolute-expiry-time": { "type": "integer", "minimum": 0 },
+        "creation-time": { "type": "integer", "minimum": 0 },
+        "conformsTo": { "type": "string", "format": "uri" },
+
+        "properties.issue_datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:issueTime/gml:TimeInstant/gml:timePosition",
+                "notes": "Issue/publication time from root METAR/SPECI element"
+            }
+        },
+        "properties.datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:observationTime/gml:TimeInstant/gml:timePosition",
+                "notes": "Observation time for METAR/SPECI"
+            }
+        },
+        "properties.start_datetime": { "$ref": "#/$defs/rfc3339" },
+        "properties.end_datetime": { "$ref": "#/$defs/rfc3339" },
+
+        "properties.icao_location_identifier": {
+            "type": "string",
+            "pattern": "^[A-Z0-9]{4}$",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:aerodrome/aixm:AirportHeliport//aixm:locationIndicatorICAO",
+                "notes": "Aerodrome ICAO code; use descendant axis to allow intermediate elements"
+            }
+        },
+        "properties.icao_location_type": {
+            "type": "string",
+            "const": "AD"
+        },
+        "properties.report_status": {
+            "type": "string",
+            "enum": ["NORMAL", "AMENDMENT", "CORRECTION"],
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//@reportStatus",
+                "notes": "IWXXM attribute reportStatus on root element"
+            }
+        },
+        "geometry.type": {
+            "type": "string",
+            "enum": ["Point"],
+            "x-iwxxm": {
+                "xpath": "//aixm:ARP/aixm:ElevatedPoint/gml:pos",
+                "notes": "Split gml:pos 'lat lon' into two doubles"
+            }
+        },
+        "geometry.coordinates.latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+        },
+        "geometry.coordinates.longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        }
+    },
+    "required": [
+        "subject",
+        "content-type",
+        "properties.issue_datetime",
+        "properties.datetime",
+        "properties.icao_location_identifier",
+        "properties.icao_location_type",
+        "properties.report_status"
+    ],
+    "optional": [
+        "geometry.type",
+        "geometry.coordinates.latitude",
+        "geometry.coordinates.longitude"
+    ],
+    "allOf": [
+        {
+            "if": { "required": ["address"] },
+            "then": {
+                "properties": { "subject": { "const": { "$data": "1/address" } } }
+            }
+        }
+    ],
+    "$defs": {
+        "rfc3339": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "Z$",
+            "description": "RFC3339 UTC (must end with 'Z')."
+        }
+    }
+}

--- a/schema/cp1/sigmet.json
+++ b/schema/cp1/sigmet.json
@@ -1,0 +1,128 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/iblsoft/swimdemo/schema/sigmet.json",
+    "title": "MET-SWIM AMQP CP1 Message - SIGMET",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "address": { "type": "string", "enum": ["weather.aviation.sigmet"] },
+        "priority": { "type": "integer", "minimum": 0, "maximum": 9 },
+        "subject": { "type": "string", "const": "weather.aviation.sigmet" },
+        "content-type": { "type": "string", "const": "application/xml" },
+        "content-encoding": { "type": "string", "enum": ["gzip", "identity"] },
+        "absolute-expiry-time": { "type": "integer", "minimum": 0 },
+        "creation-time": { "type": "integer", "minimum": 0 },
+        "conformsTo": { "type": "string", "format": "uri" },
+
+        "properties.issue_datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:issueTime/gml:TimeInstant/gml:timePosition",
+                "notes": "Issue/publication time of the SIGMET"
+            }
+        },
+        "properties.start_datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:validPeriod/gml:TimePeriod/gml:beginPosition",
+                "notes": "Start of validity period"
+            }
+        },
+        "properties.end_datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:validPeriod/gml:TimePeriod/gml:endPosition",
+                "notes": "End of validity period"
+            }
+        },
+        "properties.datetime": { "$ref": "#/$defs/rfc3339" },
+
+        "properties.icao_location_identifier": {
+            "type": "string",
+            "pattern": "^[A-Z0-9]{4}$",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:issuingAirTrafficServicesRegion/aixm:Airspace//aixm:designator",
+                "notes": "Airspace designator (e.g., FIR code)"
+            }
+        },
+        "properties.icao_location_type": {
+            "type": "string",
+            "enum": ["FIR", "UIR", "CTA", "OTHER:FIR_UIR"],
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:issuingAirTrafficServicesRegion/aixm:Airspace//aixm:type",
+                "notes": "Airspace type (FIR, UIR, CTA, combined FIR/UIR)"
+            }
+        },
+        "properties.report_status": {
+            "type": "string",
+            "enum": ["NORMAL", "AMENDMENT", "CORRECTION"],
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//@reportStatus",
+                "notes": "SIGMET report status"
+            }
+        },
+        "geometry.type": {
+            "type": "string",
+            "enum": ["Bounding-box"]
+        },
+        "geometry.coordinates.latitude-min": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+        },
+        "geometry.coordinates.latitude-max": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+        },
+        "geometry.coordinates.longitude-min": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        },
+        "geometry.coordinates.longitude-max": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        }
+    },
+    "required": [
+        "subject",
+        "content-type",
+        "properties.issue_datetime",
+        "properties.start_datetime",
+        "properties.end_datetime",
+        "properties.icao_location_identifier",
+        "properties.icao_location_type",
+        "properties.report_status"
+    ],
+    "optional": [
+        "geometry.type",
+        "geometry.coordinates.latitude-min",
+        "geometry.coordinates.latitude-max",
+        "geometry.coordinates.longitude-max",
+        "geometry.coordinates.longitude-min"
+    ],
+    "allOf": [
+        {
+            "if": { "required": ["address"] },
+            "then": {
+                "properties": { "subject": { "const": { "$data": "1/address" } } }
+            }
+        }
+    ],
+    "$defs": {
+        "rfc3339": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "Z$",
+            "description": "RFC3339 UTC (must end with 'Z')."
+        }
+    }
+}

--- a/schema/cp1/taf.json
+++ b/schema/cp1/taf.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/iblsoft/swimdemo/schema/taf.json",
+    "title": "MET-SWIM AMQP CP1 Message - TAF",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "address": { "type": "string", "enum": ["weather.aviation.taf"] },
+        "priority": { "type": "integer", "minimum": 0, "maximum": 9 },
+        "subject": { "type": "string", "const": "weather.aviation.taf" },
+        "content-type": { "type": "string", "const": "application/xml" },
+        "content-encoding": { "type": "string", "enum": ["gzip", "identity"] },
+        "absolute-expiry-time": { "type": "integer", "minimum": 0 },
+        "creation-time": { "type": "integer", "minimum": 0 },
+        "conformsTo": { "type": "string", "format": "uri" },
+
+        "properties.issue_datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:issueTime/gml:TimeInstant/gml:timePosition",
+                "notes": "Issue/publication time of the TAF"
+            }
+        },
+        "properties.start_datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:validPeriod/gml:TimePeriod/gml:beginPosition",
+                "notes": "Start of validity period"
+            }
+        },
+        "properties.end_datetime": {
+            "$ref": "#/$defs/rfc3339",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:validPeriod/gml:TimePeriod/gml:endPosition",
+                "notes": "End of validity period"
+            }
+        },
+        "properties.datetime": { "$ref": "#/$defs/rfc3339" },
+
+        "properties.icao_location_identifier": {
+            "type": "string",
+            "pattern": "^[A-Z0-9]{4}$",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//iwxxm:aerodrome/aixm:AirportHeliport//aixm:locationIndicatorICAO",
+                "notes": "Aerodrome ICAO code"
+            }
+        },
+        "properties.icao_location_type": {
+            "type": "string",
+            "const": "AD",
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "",
+                "notes": "Constant 'AD' because TAF is for an aerodrome"
+            }
+        },
+        "properties.report_status": {
+            "type": "string",
+            "enum": ["NORMAL", "AMENDMENT", "CORRECTION"],
+            "x-iwxxm": {
+                "source": "iwxxm",
+                "xpath": "//@reportStatus",
+                "notes": "TAF report status"
+            }
+        },
+        "geometry.type": {
+            "type": "string",
+            "enum": ["Point"],
+            "x-iwxxm": {
+                "xpath": "//aixm:ARP/aixm:ElevatedPoint/gml:pos",
+                "notes": "Split gml:pos 'lat lon' into two doubles"
+            }
+        },
+        "geometry.coordinates.latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+        },
+        "geometry.coordinates.longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        }
+    },
+    "required": [
+        "subject",
+        "content-type",
+        "properties.issue_datetime",
+        "properties.start_datetime",
+        "properties.end_datetime",
+        "properties.icao_location_identifier",
+        "properties.icao_location_type",
+        "properties.report_status"
+    ],
+    "optional": [
+        "geometry.type",
+        "geometry.coordinates.latitude",
+        "geometry.coordinates.longitude"
+    ],
+    "allOf": [
+        {
+            "if": { "required": ["address"] },
+            "then": {
+                "properties": { "subject": { "const": { "$data": "1/address" } } }
+            }
+        }
+    ],
+    "$defs": {
+        "rfc3339": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "Z$",
+            "description": "RFC3339 UTC (must end with 'Z')."
+        }
+    }
+}


### PR DESCRIPTION
Hi!

I am proposing to add this message schema to simplify validation of message header structure. We also added a feature "xpath" wich contains the official standard path in the IWXXM XML payload wherein to retrieve the application properties header values and geometry. The geometry field is set as optional to reflect the SWIM CP1 requirements and will be mandatory in upcoming NEXT versions of the schemas. It is highly appreciated if you can review the xpath locations and the schema for accuracy and validity this is considered a first draft.

Thank you and est regards,
Daniel H and the SMHI Aviation Team